### PR TITLE
macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*~
+*.s
+*.i
+*.o
+*.d
+*.so
+*.so.*
+*.dylib
+*.dylib.*
+*.pyc
+cscope*
+sample
+test-misc
+mrbuild

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ DIST_BIN_EXCEPT := *
 DIST_INCLUDE += \
   dogleg.h
 
-LDLIBS += -lcholmod -llapack
+LDLIBS += -lcholmod -llapack -lsuitesparseconfig
 LDLIBS += -lm
 
 CFLAGS += -Wall -Wextra -I/usr/include/suitesparse

--- a/dogleg.h
+++ b/dogleg.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <cholmod.h>
+#include <suitesparse/cholmod.h>
 #include <stdbool.h>
 
 typedef void (dogleg_callback_t)(// in


### PR DESCRIPTION
This fixes the linking of `cholmod` from `suitesparse` when utilized from a `brew` installation on macOS. I also added a `.gitignore` file. This may break the Linux build.